### PR TITLE
Add logic to flap ports to finalize_rescue.bash

### DIFF
--- a/lib/finalize_rescue.bash
+++ b/lib/finalize_rescue.bash
@@ -74,9 +74,36 @@ fi
 # Set rescue password based on hash
 sed -ie "s/^\(${safeRescueUsername}\):[^:]*:\(.*\)/\1:${safeRescueHash}:\2/" /etc/shadow
 
-
 # Activate network settings.  Performed twice as a work around for vlans on bonded inferface
 systemctl restart systemd-networkd.service
 sleep 10
 systemctl restart systemd-networkd.service
 
+# Sometimes Rescue will come up with one or both ethernet interfaces up but
+# not enslaved to the bond; this script automatically downs the interfaces
+# if they are not already enslaved to the bond, and re-ups them (if needed)
+for IF in eth0 eth1; do
+    linkinfo=`ip link show dev $IF | head -n1`
+    if echo $linkinfo | grep -q ',UP,'; then
+        if echo $linkinfo | grep -q ',SLAVE,'; then
+            echo "Link $IF is up and enslaved, continuing"
+        else
+            echo "Link $IF is up and not enslaved, flapping"
+            ip link set dev $IF down
+            # Typically, at this point, the interface will automatically be
+            # brought up and enslaved automatically to the bond, but sometimes
+            # this doesn't happen so check manually and fix, after giving
+            # CoreOS enough time to do the right thing.
+            sleep 5
+            newlinkinfo=`ip link show dev $IF | head -n1`
+            if echo $newlinkinfo | grep -q 'SLAVE,UP'; then
+                echo "Link $IF brought up automatically and enslaved"
+            elif echo $newlinkinfo | grep -q ',UP'; then
+                echo "Link $IF brought up automatically and not enslaved, uh oh"
+            else
+                echo "Link $IF still down, bringing up manually"
+                ip link set dev $IF up
+            fi
+        fi
+    fi
+done


### PR DESCRIPTION
Often rescue comes up with one or both ethernet ports not properly
joined to the bond. So, after we expect everything to be working,
we check and if it's not working right, flap the ethernet ports to
force the fix.